### PR TITLE
Added Apple Silicon compatibility with onnxruntime

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -75,7 +75,7 @@ HOW CAN I START WITH WALDO?
 
 Setup the environment with python3:
 1. (optional) create a virtual python env for the project
-2. install dependencies using the requirements file: pip install -r requirements.txt 
+2. install dependencies using the `setup.py` file: `python3 setup.py install`
 
 You may need to install a couple of other bits and pieces depending on your python3 env...
 If you find anything really blocking send me an email and I'll update this readme.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-numpy==1.23.5
-onnxruntime_gpu==1.15.1
-opencv_contrib_python==4.5.5.62
-opencv_python_headless==4.7.0.72
-Pillow==10.0.0
-Requests==2.31.0
-torch==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import platform
 from setuptools import setup
 
 # Determine the right package based on the user's system
-onnx_dependency = 'onnxruntime-silicon' if platform.system(
+onnx_dependency = 'onnxruntime-silicon==1.16.0' if platform.system(
 ) == 'Darwin' and platform.machine() == 'arm64' else 'onnxruntime-gpu==1.15.1'
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+import platform
+from setuptools import setup
+
+# Determine the right package based on the user's system
+onnx_dependency = 'onnxruntime-silicon' if platform.system(
+) == 'Darwin' and platform.machine() == 'arm64' else 'onnxruntime-gpu==1.15.1'
+
+setup(
+    name='WALDO',
+    version='2.5',
+    description=
+    'W.A.L.D.O. Whereabouts Ascertainment for Low-lying Detectable Objects',
+    author='Stephan Sturges',
+    author_email='stephan.sturges@gmail.com',
+    url='https://github.com/stephansturges/WALDO',
+    install_requires=[
+        'numpy==1.23.5', 'opencv_contrib_python==4.5.5.62',
+        'opencv_python_headless==4.7.0.72', 'Pillow==10.0.0',
+        'Requests==2.31.0', 'torch==2.0.0', onnx_dependency
+    ],
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        # Add more classifiers as needed
+    ])


### PR DESCRIPTION
Closes #15 

**TL;DR:** Replaced `requirements.txt` with `setup.py` and allow for Apple Silicon compatibility.

**Summary:**

I made an important update to the installation process to improve the compatibility of WALDO for Apple Silicon processors.

1. I removed the `requirements.txt` file and replaced it with a `setup.py` file, which allows for multiple options for a given dependency. In this case, to ensure compatibility with Apple Silicon, I've replaced the previous `onnxruntime-gpu` dependency with `onnxruntime-silicon`, which can be found on PyPI [here](https://pypi.org/project/onnxruntime-silicon/). 
    - Please feel free to change or ask for revisions to any of the parameters in the `setup` function (i.e., description, classifiers, etc.)
3. I updated the README to reflect these changes and provide clear instructions on how to install the project.